### PR TITLE
Update to StressEngine.m

### DIFF
--- a/StressEngine.m
+++ b/StressEngine.m
@@ -53,13 +53,12 @@ function result = StressEngine(xxi, xxj, z, f, alpha, beta, fsigma, rm)
             signth = -1;
         end 
         th1    = signth*acos(costh1);     %faster than cos(asin(stuff));
-        s2  = -(f(k)*oneoverpirm)*(-sin(a)); %uniform compression from boundary, sin(pi-a) = -sin(a)
         s1 	= -(f(k)*twooverpi)/(r1n)*costh1;
-        sr 	= s1-s2;
         th 	= th1-beta(k)-alpha(k);              %rotate coordinates
-        sigmaxx = sigmaxx + sr*((sin(th))^2);
-        sigmayy = sigmayy + sr*((cos(th))^2);
-        sigmaxy = sigmaxy + 0.5*s1*(sin(2*th));% + s2;
+        sigmaxx = sigmaxx + s1*((sin(th))^2);
+        sigmayy = sigmayy + s1*((cos(th))^2);
+        sigmaxy = sigmaxy + 0.5*s1*(sin(2*th));
+	
    end %end of k loop over beta, alpha
    aa     = real(sqrt((sigmaxx-sigmayy)^2+4*(sigmaxy)^2));
    result = (sin(pioverfsigma*aa))^2;  %wrap    = sin(2*pi*t/fsigma*a).^2;


### PR DESCRIPTION
Removed stress free boundary term to ensure that fringe pattern produced by StressEngine.m is correct.

Stress free boundary term is isotropic, and therefore should not be included in the principle stress difference calculation. Previously this boundary term was included with the 's1' term, prior to rotation into a cartesian coordinate system. This led to incorrect fringe patterns being produced when the contact forces were non-normal, becoming more obvious for larger forces. To rectify this issue, the 's2' term has been removed from the calculation, leading to theoretical fringe patterns that match observed fringe patterns more closely.

These findings were communicated at the Photoelastic Retreat that took place in November 2023. 

Ben McMillan (bm583@cam.ac.uk)