### PR TITLE
Fix for disksolve bug

### DIFF
--- a/PeGSDiskSolve.m
+++ b/PeGSDiskSolve.m
@@ -51,20 +51,9 @@ fitoptions = optimoptions('lsqnonlin','Algorithm','levenberg-marquardt','MaxIter
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     
 nFrames = length(files); %how many files are we processing ?
-% for frame = 1:nFrames %loop over these frames 
-% 
-%     fileName = [directory,files(frame).name]; %which file/frame are we processing now ?
-%     maskradius = maskradius / 2; %I did an unwise choice in naming this
-%     data =load(fileName); %load the particle data file to process
-%     %initialize a copy of the particle vector to mess around with
-%     particle = data.particle
-%     disksolve2(particle, maskradius, scaling, fileName)
-    
-%end
-    
+
+
 for frame = 1:nFrames %loop over these frames 
-%for frame =1:9
-    %frame = frame
     fileName = [directory,files(frame).name];
     data = load(fileName);
     particle = data.particle;

--- a/PeGSDiskSolve.m
+++ b/PeGSDiskSolve.m
@@ -39,7 +39,7 @@ maskradius = 0.96;%
 scaling = 0.5; %scale the image by this factor before doing the fit
 
 %do we want to see each particle on screen while it is fitted ?
-verbose = true; 
+verbose = false; 
 
 %fit options: play around with these, depending on the quality of your
 %images and the accuracy you want your result to have. 
@@ -51,111 +51,22 @@ fitoptions = optimoptions('lsqnonlin','Algorithm','levenberg-marquardt','MaxIter
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     
 nFrames = length(files); %how many files are we processing ?
-for frame = 1:nFrames %loop over these frames 
-
-    fileName = [directory,files(frame).name]; %which file/frame are we processing now ?
-    maskradius = maskradius / 2; %I did an unwise choice in naming this
-    load(fileName); %load the particle data file to process
-    pres=particle; %initialize a copy of the particle vector to mess around with
-    N = length(particle); %number of particles in this frame
+% for frame = 1:nFrames %loop over these frames 
+% 
+%     fileName = [directory,files(frame).name]; %which file/frame are we processing now ?
+%     maskradius = maskradius / 2; %I did an unwise choice in naming this
+%     data =load(fileName); %load the particle data file to process
+%     %initialize a copy of the particle vector to mess around with
+%     particle = data.particle
+%     disksolve2(particle, maskradius, scaling, fileName)
     
-    display(['processing file ',fileName, 'containing ' ,num2str(N), 'particles']); %status indicator
-
-    for n=1:N
-        display(['fitting force(s) to particle ',num2str(n)]); %status indicator
-        if (particle(n).z > 0 )
-                    %bookkeeping
-                    fsigma = particle(n).fsigma;
-                    %fsigma = 80;
-                    rm = particle(n).rm;
-
-%                     %This is the Camera Image
-%   %template = im2double(particle(n).forceImage);
-                     template = particle(n).forceImage;
-                     template = imresize(template,scaling);
-%                     template = template-0.1;
-%                     %template = (template -0.2); %fine tunes the image, this should happen in preprocessing!
-%                     template = template.*(template > 0); %fine tunes the image, this should happen in preprocessing!
-%                     template = template*3; %fine tunes the image, this should happen in preprocessing!
-
-                    %size of the force image
-                    px = size(template,1); 
-                    
-                    %plot the experimental image that is going to be fitted
-                    %onto
-                    if verbose
-                        subplot(1,2,1)
-                        imshow(template);
-                    end
-                    
-                    %Create initial guesses for each contact force, based
-                    %on the gradient squared in the contact region (also
-                    %better guess lower than too high)
-                    z = particle(n).z;
-                    forces = zeros(z,1);
-                    cg2s = sum(particle(n).contactG2s);
-
-                    for i=1:z
-                            forces(i)=2*particle(n).f*particle(n).contactG2s(i)/cg2s;%initial guess for force
-                    end
-
-                    %Initial guesses for the angles of attack of the forces
-                    %for each contact
-                    alphas = zeros(z,1);
-                    beta = particle(n).betas;
-
-                    %apply force balance to the initial guesses
-                    [alphas,forces] = forceBalance(forces,alphas,beta);
-
-                    %create a circular mask
-                    cx=px/2;cy=px/2;ix=px;iy=px;r=maskradius*px;
-                    [x,y]=meshgrid(-(cx-1):(ix-cx),-(cy-1):(iy-cy));
-                    c_mask=((x.^2+y.^2)<=r^2);   
-
-                    %This is the function we want to fit, i.e. a synthetic
-                    %version of the force image with free parameters f (here called par(1:z)) and
-                    %alpha (here called par(z+1:z*z) since we have to stuff
-                    %them into one vector.
-                    func = @(par) joForceImg(z, par(1:z),par(z+1:z+z), beta(1:z), fsigma, rm, px, verbose); %+par(2*z+1); %this is the function I want to fit (i.e. synthetic stres image), the fitting paramters are in vector par
-                    %This is the error function we are actually fitting,
-                    %that is, the distance between our fit function and the
-                    %real particle image in terms of the sum of squares of the pixelwise differnce.
-                    %Also a mask is applied to crop
-                    %out only the circular part of the particle. 
-                    err = @(par) real(sum(sum( ( c_mask.*(template-func(par)).^2) ))); %BUG: for some reason I sometimes get imaginary results, this should not happen
-
-                    %Set up initial guesses
-                    p0(1:z) = forces;
-                    p0(z+1:2*z) = alphas;
-
-                    %Do the fit, will also work with other solvers
-                    %TODO: make a user defined option to select between
-                    %different solvers
-                    p=lsqnonlin(err,p0,[],[],fitoptions);
-
-                    %get back the result from fitting
-                    forces = p(1:z);
-                    alphas = p(z+1:z+z);
-
-                    %resudual
-                    fitError = err(p);
-                    
-                    %generate an image with the fitted parameters
-                    imgFit = joForceImg(z, forces, alphas, beta, fsigma, rm, px*(1/scaling), verbose);
-                    
-                    %since the image gnerator also forces force balance we
-                    %have to explicitly do it once more to the values we
-                    %are gonna save 
-                    [alphas,forces] = forceBalance(forces,alphas,beta);
-                    
-                    %store the new information into a new particle vector 
-                    pres(n).fitError = fitError;
-                    pres(n).forces = forces;
-                    pres(n).alphas = alphas;
-                    pres(n).synthImg = imgFit;
-        end
-    end
-    %save the result
-    save([fileName(1:end-17),'solved.mat'],'pres');
+%end
+    
+for frame = 1:nFrames %loop over these frames 
+%for frame =1:9
+    %frame = frame
+    fileName = [directory,files(frame).name];
+    data = load(fileName);
+    particle = data.particle;
+    particle = disksolve(particle, maskradius, scaling, fileName, verbose, fitoptions);
 end
-

--- a/disksolve.m
+++ b/disksolve.m
@@ -1,0 +1,103 @@
+function particle = disksolve(particle, maskradius, scaling, fileName, verbose, fitoptions)
+    pres=particle;
+    N = length(particle); %number of particles in this frame
+    
+    display(['processing file ',fileName, 'containing ' ,num2str(N), 'particles']); %status indicator
+
+    for n=1:N
+        display(['fitting force(s) to particle ',num2str(n)]); %status indicator
+        if (particle(n).z > 0 )
+                    %bookkeeping
+                    fsigma = particle(n).fsigma;
+                    %fsigma = 80;
+                    rm = particle(n).rm;
+
+%                     %This is the Camera Image
+%   %template = im2double(particle(n).forceImage);
+                     template = particle(n).forceImage;
+                     template = imresize(template,scaling);
+%                     template = template-0.1;
+%                     %template = (template -0.2); %fine tunes the image, this should happen in preprocessing!
+%                     template = template.*(template > 0); %fine tunes the image, this should happen in preprocessing!
+%                     template = template*3; %fine tunes the image, this should happen in preprocessing!
+
+                    %size of the force image
+                    px = size(template,1); 
+                    
+                    %plot the experimental image that is going to be fitted
+                    %onto
+                    if verbose
+                        subplot(1,2,1)
+                        imshow(template);
+                    end
+                    
+                    %Create initial guesses for each contact force, based
+                    %on the gradient squared in the contact region (also
+                    %better guess lower than too high)
+                    z = particle(n).z;
+                    forces = zeros(z,1);
+                    cg2s = sum(particle(n).contactG2s);
+
+                    for i=1:z
+                            forces(i)=2*particle(n).f*particle(n).contactG2s(i)/cg2s;%initial guess for force
+                    end
+
+                    %Initial guesses for the angles of attack of the forces
+                    %for each contact
+                    alphas = zeros(z,1);
+                    beta = particle(n).betas;
+
+                    %apply force balance to the initial guesses
+                    [alphas,forces] = forceBalance(forces,alphas,beta);
+
+                    %create a circular mask
+                    cx=px/2;cy=px/2;ix=px;iy=px;r=maskradius*px;
+                    [x,y]=meshgrid(-(cx-1):(ix-cx),-(cy-1):(iy-cy));
+                    c_mask=((x.^2+y.^2)<=r^2);   
+
+                    %This is the function we want to fit, i.e. a synthetic
+                    %version of the force image with free parameters f (here called par(1:z)) and
+                    %alpha (here called par(z+1:z*z) since we have to stuff
+                    %them into one vector.
+                    func = @(par) joForceImg(z, par(1:z),par(z+1:z+z), beta(1:z), fsigma, rm, px, verbose); %+par(2*z+1); %this is the function I want to fit (i.e. synthetic stres image), the fitting paramters are in vector par
+                    %This is the error function we are actually fitting,
+                    %that is, the distance between our fit function and the
+                    %real particle image in terms of the sum of squares of the pixelwise differnce.
+                    %Also a mask is applied to crop
+                    %out only the circular part of the particle. 
+                    err = @(par) real(sum(sum( ( c_mask.*(template-func(par)).^2) ))); %BUG: for some reason I sometimes get imaginary results, this should not happen
+
+                    %Set up initial guesses
+                    p0(1:z) = forces;
+                    p0(z+1:2*z) = alphas;
+
+                    %Do the fit, will also work with other solvers
+                    %TODO: make a user defined option to select between
+                    %different solvers
+                    p=lsqnonlin(err,p0,[],[],fitoptions);
+
+                    %get back the result from fitting
+                    forces = p(1:z);
+                    alphas = p(z+1:z+z);
+
+                    %resudual
+                    fitError = err(p);
+                    
+                    %generate an image with the fitted parameters
+                    imgFit = joForceImg(z, forces, alphas, beta, fsigma, rm, px*(1/scaling), verbose);
+                    
+                    %since the image gnerator also forces force balance we
+                    %have to explicitly do it once more to the values we
+                    %are gonna save 
+                    [alphas,forces] = forceBalance(forces,alphas,beta);
+                    
+                    %store the new information into a new particle vector 
+                    pres(n).fitError = fitError;
+                    pres(n).forces = forces;
+                    pres(n).alphas = alphas;
+                    pres(n).synthImg = imgFit;
+        end
+    end
+    %save the result
+    save([fileName(1:end-17),'solved.mat'],'pres');
+end

--- a/disksolve.m
+++ b/disksolve.m
@@ -2,9 +2,9 @@ function particle = disksolve(particle, maskradius, scaling, fileName, verbose, 
     pres=particle;
     N = length(particle); %number of particles in this frame
     
-    display(['processing file ',fileName, 'containing ' ,num2str(N), 'particles']); %status indicator
+    disp(['processing file ',fileName, 'containing ' ,num2str(N), 'particles']); %status indicator
 
-    for n=1:N
+    parfor (n=1:N)
         display(['fitting force(s) to particle ',num2str(n)]); %status indicator
         if (particle(n).z > 0 )
                     %bookkeeping
@@ -68,8 +68,10 @@ function particle = disksolve(particle, maskradius, scaling, fileName, verbose, 
                     err = @(par) real(sum(sum( ( c_mask.*(template-func(par)).^2) ))); %BUG: for some reason I sometimes get imaginary results, this should not happen
 
                     %Set up initial guesses
+                    p0 = zeros(2*z, 1);
                     p0(1:z) = forces;
                     p0(z+1:2*z) = alphas;
+
 
                     %Do the fit, will also work with other solvers
                     %TODO: make a user defined option to select between

--- a/joForceImg.m
+++ b/joForceImg.m
@@ -23,7 +23,7 @@ function img = joForceImg (z, f, alpha, beta, fsigma, rm, px, verbose)
 
     %Create a scale that maps the diameter of the particle onto the image size
     xx = linspace(-rm, rm, px); 
-    parfor (x=1:px) %loop throgh image width
+    for x=1:px %loop throgh image width
         xRow=zeros(px,1); %placeholder for the current row beeing prcessed, parallel for makes it necessary to split up the result data and later combine it
         for y=1:px  %loop throgh image height
             if ((xx(x)^2+xx(y)^2)<=rm^2) %check if we are actually inside


### PR DESCRIPTION
Changing the solving portion of the code to be a function that is called by PeGSDiskSolve. For whatever reason, this fixes the bug where the solver stops solving all of the particles for images beyond the first one. This can be reproduced by simply copying the same test image 3 times in the directory and the resulting synthetic image is quite different image 2 and 3 in the series. To my knowledge this error appear in versions of matlab beyond 2022a.

